### PR TITLE
add fr dictionary

### DIFF
--- a/crates/codebook/src/dictionaries/repo.rs
+++ b/crates/codebook/src/dictionaries/repo.rs
@@ -80,6 +80,11 @@ static HUNSPELL_DICTIONARIES: LazyLock<Vec<HunspellRepo>> = LazyLock::new(|| {
             "https://raw.githubusercontent.com/wooorm/dictionaries/refs/heads/main/dictionaries/de-CH/index.dic",
         ),
         HunspellRepo::new(
+            "fr",
+            "https://raw.githubusercontent.com/wooorm/dictionaries/refs/heads/main/dictionaries/fr/index.aff",
+            "https://raw.githubusercontent.com/wooorm/dictionaries/refs/heads/main/dictionaries/fr/index.dic",
+        ),
+        HunspellRepo::new(
             "ru",
             "https://raw.githubusercontent.com/wooorm/dictionaries/refs/heads/main/dictionaries/ru/index.aff",
             "https://raw.githubusercontent.com/wooorm/dictionaries/refs/heads/main/dictionaries/ru/index.dic",


### PR DESCRIPTION
I have tested it locally and it seems to work as expected (added `fr` to the `dictionaries` entry in `codebook.toml` and typed a bunch of French text).

idk if there are more specific tests that i can run