### PR TITLE
Update README with Installation and Table Of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <br />
 <div align="center">
   <a href="https://github.com/blopker/codebook"> <img
@@ -72,6 +73,14 @@ Suggestions will appear in files opened, and
 [space-mode](https://docs.helix-editor.com/keymap.html#space-mode) `a` key
 binding can be used to accept suggestions.
 
+### Other Editors
+
+Any editor that implements the Language Server Protocol should be compatible with Codebook. To get started, follow the [installation instructions](#installation), then consult your editor's documentation to learn how to configure and enable a new language server. For your reference, the following command starts the server such that it listens on `STDIN` and emits on `STDOUT`:
+
+```sh
+codebook-lsp serve
+```
+
 ## About
 
 Codebook is a spellchecker for code. It binds together the venerable Tree Sitter and the fast spell checker [Spellbook](https://github.com/helix-editor/spellbook). Included is a Language Server for use in (theoretically) any editor. Everything is done in Rust to keep response times snappy and memory usage _low_.
@@ -108,6 +117,39 @@ Codebook is in active development. As better dictionaries are added, words that 
 ❌ = Work has started, but there are issues
 
 If Codebook is not marking issues you think it should, please file a GitHub issue!
+
+## Installation
+
+If you are a Zed user, you may skip this step and consult the [Zed section](#zed) of this document. Otherwise, you will need to install the `codebook-lsp` binary and make it available on your `$PATH`. You have a number of options to do this.
+
+### Manual
+
+1. Download the latest release for your architecture from the [releases](https://github.com/blopker/codebook/releases) page.
+2. Extract the binary from the tarball, and move it somewhere on your system `$PATH`.
+  - `~/.local/bin/codebook-lsp`
+  - `/usr/bin/codebook-lsp`
+  - Etc...
+
+### Eget Installation
+
+You can install the latest release using [eget](https://github.com/zyedidia/eget):
+
+```sh
+eget blopker/codebook
+```
+
+### Arch User Repository
+
+The binary release is available on the AUR under the [codebook-bin](aur.archlinux.org/packages/codebook-bin) package. Arch users can easily install it with their favorite AUR helper, such as [paru](https://github.com/Morganamilo/paru):
+
+```sh
+paru -S codebook-bin
+```
+
+### From Source
+
+You may also build `codebook` from source by cloning the repository and running `make build`.
+
 
 ## Configuration
 


### PR DESCRIPTION
I recently discovered this project and really like it, but I was frustrated by the lack of easy installation instructions, so I created an [Arch User Repository package](aur.archlinux.org/packages/codebook-bin) for Codebook's binary release. In adding it to the README, I also included more precise instructions for installing from the release manually, as well as using [eget](https://github.com/zyedidia/eget). Finally, I added a table of contents under a dropdown to the top of the document because there are a lot of sections and it's easy to get lost.

Once the `cargo` installation method discussed in #61 is implemented, it could be added to this section and noted as the "preferred" way to install the package. Finally, if you think this makes the README too crammed/busy, we could wrap the installation instructions in another `<details>` dropdown. Please let me know what you think. 