### PR TITLE
Do not announce `diagnostic_provider` capability

### DIFF
--- a/crates/codebook-lsp/src/lsp.rs
+++ b/crates/codebook-lsp/src/lsp.rs
@@ -100,12 +100,6 @@ impl LanguageServer for Backend {
                         },
                     },
                 )),
-                diagnostic_provider: Some(DiagnosticServerCapabilities::Options(
-                    DiagnosticOptions {
-                        identifier: Some(SOURCE_NAME.to_string()),
-                        ..DiagnosticOptions::default()
-                    },
-                )),
                 ..ServerCapabilities::default()
             },
             server_info: Some(ServerInfo {


### PR DESCRIPTION
The `diagnostic_provider` capability should be announced when a language server supports pull mode for diagnostics.

Announcing this capability informs the client that it can pull diagnostics for a document, which helps handle failed requests.
For example, in Zed, which supports pull mode for diagnostics, you might see the following error messages:

```
2025-06-27T19:46:31+02:00 ERROR [editor] Failed to update project diagnostics: pulling diagnostics: Get diagnostics via codebook failed: Method not found
2025-06-27T19:46:31+02:00 WARN  [project::lsp_store] Get diagnostics via codebook failed: Method not found
2025-06-27T19:46:31+02:00 ERROR [editor] Failed to update project diagnostics: pulling diagnostics: Get diagnostics via codebook failed: Method not found
```

I think it would be good to stop declaring the unsupported capability but I'm happy to discuss this further if needed. Thanks!