### PR TITLE
Add pt-BR dictionary

### DIFF
--- a/crates/codebook/src/dictionaries/repo.rs
+++ b/crates/codebook/src/dictionaries/repo.rs
@@ -99,6 +99,11 @@ static HUNSPELL_DICTIONARIES: LazyLock<Vec<HunspellRepo>> = LazyLock::new(|| {
             "https://raw.githubusercontent.com/wooorm/dictionaries/refs/heads/main/dictionaries/sv/index.aff",
             "https://raw.githubusercontent.com/wooorm/dictionaries/refs/heads/main/dictionaries/sv/index.dic",
         ),
+        HunspellRepo::new(
+            "pt_br",
+            "https://raw.githubusercontent.com/streetsidesoftware/cspell-dicts/refs/heads/main/dictionaries/pt_BR/src/hunspell/index.aff",
+            "https://raw.githubusercontent.com/streetsidesoftware/cspell-dicts/refs/heads/main/dictionaries/pt_BR/src/hunspell/index.dic",
+        ),
     ]
 });
 


### PR DESCRIPTION
I'm using your spell checker in Zed Editor, and I'd like to add the pt-BR dictionary.