### PR TITLE
Add Portuguese (Brazil) to language options in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Project-specific configuration is loaded from either `codebook.toml` or `.codebo
 #  - Spanish: "es"
 #  - French: "fr"
 #  - Italian: "it"
+#  - Portuguese (Brazil): "pt_br"
 #  - Russian: "ru"
 #  - Swedish: "sv"
 dictionaries = ["en_us", "en_gb"]


### PR DESCRIPTION
Initially, I didn’t use it because the README didn’t include instructions on how to configure it in Portuguese, so I assumed it wasn’t supported. But today, when I went to implement it, I realized the support was already there. I’m now updating the README to help others who might run into the same issue.