### PR TITLE
Add new Hunspell repositories for Latin, Ancient Greek and Sanskrit

### DIFF
--- a/crates/codebook/src/dictionaries/repo.rs
+++ b/crates/codebook/src/dictionaries/repo.rs
@@ -114,6 +114,21 @@ static HUNSPELL_DICTIONARIES: LazyLock<Vec<HunspellRepo>> = LazyLock::new(|| {
             "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/da/index.aff",
             "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/da/index.dic",
         ),
+        HunspellRepo::new(
+            "la",
+            "https://raw.githubusercontent.com/gluiz1/dicionarios/main/la.aff",
+            "https://raw.githubusercontent.com/gluiz1/dicionarios/main/la.dic",
+        ),
+        HunspellRepo::new(
+            "grc",
+            "https://raw.githubusercontent.com/gluiz1/dicionarios/main/grc.aff",
+            "https://raw.githubusercontent.com/gluiz1/dicionarios/main/grc.dic",
+        ),
+        HunspellRepo::new(
+            "sa",
+            "https://raw.githubusercontent.com/gluiz1/dicionarios/main/sa.aff",
+            "https://raw.githubusercontent.com/gluiz1/dicionarios/main/sa.dic",
+        ),
     ]
 });
 


### PR DESCRIPTION
Following the discussion on #126 , I think that build up a new repository from scratch  will not be a great idea. As I need these dictionaries, I think that simplest solution was to create a new repository myself and add them. 