### PR TITLE
Add hgroup

### DIFF
--- a/word_lists/html.txt
+++ b/word_lists/html.txt
@@ -279,6 +279,7 @@ header
 heading
 height
 help
+hgroup
 hidden
 hide
 hierarchy


### PR DESCRIPTION
Hi! I hope this PR out of nowhere isn't an issue, but I realized that [`hgroup`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/hgroup) was flagged as a typo by codebook. From my limited understanding of the structure of the project, it seems as if it might just be missing from the html list, so I took the liberty of adding it here.

I assume this will also trickle down to TS/TSX and now be an allowed tag in react?

The reason I'm opening this is because of this error:
<img width="465" height="87" alt="image" src="https://github.com/user-attachments/assets/a33b9c44-0b8a-47e1-95b3-24edc1a6bf3b" />

Let me know what you think, and thanks for the project; it otherwise appears to be working pretty well for my use case.

Cheers.
