### PR TITLE
Fix missing open/close in LSP server capabilities

### DIFF
--- a/crates/codebook-lsp/src/lsp.rs
+++ b/crates/codebook-lsp/src/lsp.rs
@@ -82,6 +82,7 @@ impl LanguageServer for Backend {
                 position_encoding: Some(PositionEncodingKind::UTF16),
                 text_document_sync: Some(TextDocumentSyncCapability::Options(
                     TextDocumentSyncOptions {
+                        open_close: Some(true),
                         change: Some(TextDocumentSyncKind::FULL),
                         save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
                             include_text: Some(true),


### PR DESCRIPTION
### Summary
This PR fixes issue #179 by enabling `open_close` in `TextDocumentSyncOptions`.

Without this option, the server does not receive `textDocument/didOpen`
and `textDocument/didClose` notifications from some editors (e.g. Neovim).

### Fix
Set `open_close: Some(true)` in the server capabilities configuration.

Fixes #179