### PR TITLE
feat: add VHDL language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
  "tree-sitter-swift",
  "tree-sitter-toml-ng",
  "tree-sitter-typescript",
+ "tree-sitter-vhdl",
  "tree-sitter-yaml",
  "tree-sitter-zig",
  "unicode-segmentation",
@@ -3018,6 +3019,15 @@ name = "tree-sitter-typescript"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-vhdl"
+version = "1.3.1"
+source = "git+https://github.com/jpt13653903/tree-sitter-vhdl?tag=v1.3.1#ec2cb14f68053cf49d1d18cd5742af8e81771ebb"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ tree-sitter-swift = "<0.8.0"
 tree-sitter-toml-ng = "<0.8.0"
 tree-sitter-typescript = "0.23.2"
 tree-sitter-yaml = "0.7.2"
+tree-sitter-vhdl = { git = "https://github.com/jpt13653903/tree-sitter-vhdl", tag = "v1.3.1" }
 tree-sitter-zig = "<2"
 tree-sitter-c-sharp= "<0.24.0"
 codebook-tree-sitter-latex = "<0.7.0"

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Codebook is in active development. As better dictionaries are added, words that 
 | TOML | ✅ |
 | TypeScript | ✅ |
 | Typst | ⚠️ |
+| VHDL | ⚠️ |
 | YAML | ⚠️ |
 | Zig | ✅ |
 

--- a/crates/codebook/Cargo.toml
+++ b/crates/codebook/Cargo.toml
@@ -51,6 +51,7 @@ tree-sitter-rust.workspace = true
 tree-sitter-swift.workspace = true
 tree-sitter-toml-ng.workspace = true
 tree-sitter-typescript.workspace = true
+tree-sitter-vhdl.workspace = true
 codebook-tree-sitter-typst.workspace = true
 tree-sitter-yaml.workspace = true
 tree-sitter-zig.workspace = true

--- a/crates/codebook/src/queries.rs
+++ b/crates/codebook/src/queries.rs
@@ -29,6 +29,7 @@ pub enum LanguageType {
     Text,
     Typescript,
     Typst,
+    VHDL,
     YAML,
     Zig,
 }
@@ -246,6 +247,13 @@ pub static LANGUAGE_SETTINGS: &[LanguageSetting] = &[
         query: include_str!("queries/typst.scm"),
         extensions: &["typ"],
     },
+    LanguageSetting {
+        type_: LanguageType::VHDL,
+        ids: &["vhdl"],
+        dictionary_ids: &["vhdl"],
+        query: include_str!("queries/vhdl.scm"),
+        extensions: &["vhd", "vhdl"],
+    },
 ];
 
 #[derive(Debug)]
@@ -286,6 +294,7 @@ impl LanguageSetting {
             LanguageType::Text => None,
             LanguageType::Typescript => Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
             LanguageType::Typst => Some(codebook_tree_sitter_typst::LANGUAGE.into()),
+            LanguageType::VHDL => Some(tree_sitter_vhdl::LANGUAGE.into()),
             LanguageType::YAML => Some(tree_sitter_yaml::LANGUAGE.into()),
             LanguageType::Zig => Some(tree_sitter_zig::LANGUAGE.into()),
         }

--- a/crates/codebook/src/queries/vhdl.scm
+++ b/crates/codebook/src/queries/vhdl.scm
@@ -1,0 +1,72 @@
+; Comments - capture comment content for spell checking
+(line_comment
+  (comment_content) @comment)
+(block_comment
+  (comment_content) @comment)
+
+; String literals
+(string_literal) @string
+
+; Entity declarations
+(entity_declaration
+  entity: (identifier) @identifier)
+
+; Architecture definitions
+(architecture_definition
+  architecture: (identifier) @identifier)
+
+; Signal declarations
+(signal_declaration
+  (identifier_list
+    (identifier) @identifier))
+
+; Variable declarations
+(variable_declaration
+  (identifier_list
+    (identifier) @identifier))
+
+; Constant declarations
+(constant_declaration
+  (identifier_list
+    (identifier) @identifier))
+
+; Function specifications
+(function_specification
+  function: (identifier) @identifier)
+
+; Procedure specifications
+(procedure_specification
+  procedure: (identifier) @identifier)
+
+; Component declarations
+(component_declaration
+  component: (identifier) @identifier)
+
+; Type declarations
+(type_declaration
+  type: (identifier) @identifier)
+
+; Subtype declarations
+(subtype_declaration
+  type: (identifier) @identifier)
+
+; Port/generic interface declarations
+(interface_declaration
+  (identifier_list
+    (identifier) @identifier))
+(interface_signal_declaration
+  (identifier_list
+    (identifier) @identifier))
+(interface_variable_declaration
+  (identifier_list
+    (identifier) @identifier))
+(interface_constant_declaration
+  (identifier_list
+    (identifier) @identifier))
+
+; Labels
+(label) @identifier
+
+; Alias declarations
+(alias_declaration
+  (identifier) @identifier)

--- a/crates/codebook/tests/test_vhdl.rs
+++ b/crates/codebook/tests/test_vhdl.rs
@@ -1,0 +1,81 @@
+use codebook::{
+    parser::{TextRange, WordLocation},
+    queries::LanguageType,
+};
+
+mod utils;
+
+#[test]
+fn test_vhdl_simple() {
+    utils::init_logging();
+    let processor = utils::get_processor();
+    let sample_text = r#"
+-- This is an exmple comment with speling errors
+entity calculatr is
+    port (
+        clk     : in  std_logic;
+        resett  : in  std_logic;
+        inputt  : in  std_logic_vector(7 downto 0)
+    );
+end entity calculatr;
+"#;
+    let expected = vec![
+        "calculatr",
+        "clk",
+        "exmple",
+        "inputt",
+        "resett",
+        "speling",
+    ];
+    let binding = processor
+        .spell_check(sample_text, Some(LanguageType::VHDL), None)
+        .to_vec();
+    let mut misspelled = binding
+        .iter()
+        .map(|r| r.word.as_str())
+        .collect::<Vec<&str>>();
+    misspelled.sort();
+    println!("Misspelled words: {misspelled:?}");
+    assert_eq!(misspelled, expected);
+}
+
+#[test]
+fn test_vhdl_comment_location() {
+    utils::init_logging();
+    let sample_text = r#"
+-- A calculater for numbrs
+"#;
+    let expected = vec![
+        WordLocation::new(
+            "calculater".to_string(),
+            vec![TextRange {
+                start_byte: 6,
+                end_byte: 16,
+            }],
+        ),
+        WordLocation::new(
+            "numbrs".to_string(),
+            vec![TextRange {
+                start_byte: 21,
+                end_byte: 27,
+            }],
+        ),
+    ];
+    let not_expected = ["std_logic", "entity", "port", "signal"];
+    let processor = utils::get_processor();
+    let misspelled = processor
+        .spell_check(sample_text, Some(LanguageType::VHDL), None)
+        .to_vec();
+    println!("Misspelled words: {misspelled:?}");
+    for e in &expected {
+        println!("Expecting: {e:?}");
+        let miss = misspelled.iter().find(|r| r.word == e.word).unwrap();
+        assert!(miss.locations.len() == e.locations.len());
+        for location in &miss.locations {
+            assert!(e.locations.contains(location));
+        }
+    }
+    for result in misspelled {
+        assert!(!not_expected.contains(&result.word.as_str()));
+    }
+}

--- a/examples/example.vhd
+++ b/examples/example.vhd
@@ -1,0 +1,37 @@
+-- This is an exmple VHDL file with speling errors
+-- for testing the codebook spell checker
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- Entity declarashun for a simple calculater
+entity calculatr is
+    port (
+        clk       : in  std_logic;
+        resett    : in  std_logic;
+        inputt    : in  std_logic_vector(7 downto 0);
+        outpuut   : out std_logic_vector(7 downto 0)
+    );
+end entity calculatr;
+
+-- Architectur definition
+architecture behavorial of calculatr is
+    signal intrnal_data : std_logic_vector(7 downto 0);
+    constant max_valuue : integer := 255;
+    variable tmp_resullt : integer := 0;
+begin
+
+    -- Main proccess block
+    main_proccess : process(clk, resett)
+    begin
+        if resett = '1' then
+            intrnal_data <= (others => '0');
+        elsif rising_edge(clk) then
+            intrnal_data <= inputt;
+        end if;
+    end process main_proccess;
+
+    outpuut <= intrnal_data;
+
+end architecture behavorial;


### PR DESCRIPTION
## Summary

Add VHDL as a supported language for spell checking using the [tree-sitter-vhdl](https://github.com/jpt13653903/tree-sitter-vhdl) grammar (v1.3.1).

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Added `tree-sitter-vhdl` git dependency (not on crates.io) |
| `crates/codebook/Cargo.toml` | Added workspace dependency |
| `crates/codebook/src/queries.rs` | Added `VHDL` enum variant, language setting, match arm |
| `crates/codebook/src/queries/vhdl.scm` | Tree-sitter query capturing comments, strings, identifiers |
| `examples/example.vhd` | Example file with intentional spelling errors |
| `crates/codebook/tests/test_vhdl.rs` | 2 tests: simple spell check + byte-position verification |
| `README.md` | Added VHDL to supported languages table |

## Query Captures

- **Comments**: `line_comment`, `block_comment` (via `comment_content`)
- **Strings**: `string_literal`
- **Identifiers**: entity, architecture, signal, variable, constant, function, procedure, component, type, subtype, alias declarations
- **Ports**: `interface_declaration`, `interface_signal_declaration`, `interface_variable_declaration`, `interface_constant_declaration`
- **Labels**: `label`

## Testing

- `cargo test -p codebook --lib` — 32/32 pass (including `test_all_queries_are_valid`)
- `cargo test -p codebook --test test_vhdl` — 2/2 pass
- `make test` — full suite passes with 0 failures