### PR TITLE
Added c and cpp word list

### DIFF
--- a/word_lists/c.txt
+++ b/word_lists/c.txt
@@ -1,0 +1,5 @@
+nolintbegin
+nolintend
+nolintnextline
+nullptr
+tparam

--- a/word_lists/cpp.txt
+++ b/word_lists/cpp.txt
@@ -1,0 +1,6 @@
+chrono
+nolintbegin
+nolintend
+nolintnextline
+nullptr
+tparam


### PR DESCRIPTION
note that c23 supports nullptr as well, tparam comes from doxygen which is often used for docstrings