### PR TITLE
Added C++ modules extension

### DIFF
--- a/crates/codebook/src/queries.rs
+++ b/crates/codebook/src/queries.rs
@@ -84,7 +84,7 @@ pub static LANGUAGE_SETTINGS: &[LanguageSetting] = &[
         ids: &["cpp", "c++"],
         dictionary_ids: &["cpp"],
         query: include_str!("queries/cpp.scm"),
-        extensions: &["cpp", "cc", "cxx", "hpp", "hh", "hxx"],
+        extensions: &["cpp", "cc", "cxx", "hpp", "hh", "hxx", "cppm", "ixx", "mxx"],
     },
     LanguageSetting {
         type_: LanguageType::Elixir,


### PR DESCRIPTION
This allows to detect C++ modules. Modules are a feature that got added in `C++20`. They normally have a `cppm` extension, sometimes (mostly MSVC) a `ixx` or `mxx`.

https://en.wikipedia.org/wiki/Modules_(C%2B%2B)