### PR TITLE
Add Portuguese (Portugal) Hunspell repositories

### DIFF
--- a/crates/codebook/src/dictionaries/repo.rs
+++ b/crates/codebook/src/dictionaries/repo.rs
@@ -149,6 +149,16 @@ static HUNSPELL_DICTIONARIES: LazyLock<Vec<HunspellRepo>> = LazyLock::new(|| {
             "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/uk/index.aff",
             "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/uk/index.dic",
         ),
+        HunspellRepo::new(
+            "pt_pt",
+            "https://raw.githubusercontent.com/streetsidesoftware/cspell-dicts/refs/heads/main/dictionaries/pt_PT/src/hunspell/Portuguese-European.aff",
+            "https://raw.githubusercontent.com/streetsidesoftware/cspell-dicts/refs/heads/main/dictionaries/pt_PT/src/hunspell/Portuguese-European.dic",
+        ),
+        HunspellRepo::new(
+            "pt",
+            "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/pt/index.aff",
+            "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/pt/index.dic",
+        ),
     ]
 });
 


### PR DESCRIPTION
Repositories for "pt_PT" and "pt" locales added, using the dictionaries from "https://github.com/streetsidesoftware/cspell-dicts/" and "https://github.com/blopker/dictionaries/".