### PR TITLE
Add Czech (cs) dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Project-specific configuration is loaded from either `codebook.toml` or `.codebo
 # Default: ["en_us"]
 # Available dictionaries:
 #  - English: "en_us", "en_gb"
+#  - Czech: "cs"
 #  - German: "de", "de_at", "de_ch"
 #  - Dutch: "nl_nl"
 #  - Spanish: "es"

--- a/crates/codebook/src/dictionaries/repo.rs
+++ b/crates/codebook/src/dictionaries/repo.rs
@@ -60,6 +60,11 @@ static HUNSPELL_DICTIONARIES: LazyLock<Vec<HunspellRepo>> = LazyLock::new(|| {
             "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/en-GB/index.dic",
         ),
         HunspellRepo::new(
+            "cs",
+            "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/cs/index.aff",
+            "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/cs/index.dic",
+        ),
+        HunspellRepo::new(
             "es",
             "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/es/index.aff",
             "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/es/index.dic",


### PR DESCRIPTION
## Summary

- Adds Czech (`cs`) Hunspell dictionary to `HUNSPELL_DICTIONARIES` in `repo.rs`
- Updates the README's available dictionaries list to include Czech
- The dictionary files already exist in the [blopker/dictionaries](https://github.com/blopker/dictionaries/tree/main/dictionaries/cs) fork — this PR just wires them up

## Usage

```toml
dictionaries = ["en_us", "cs"]
```

## Test plan

- [x] `test_dictionary_names_unique_and_snake_case` passes
- [ ] Verify Czech dictionary downloads and spell-checks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)