### PR TITLE
Add Persian/Farsi dictionary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Project-specific configuration is loaded from either `codebook.toml` or `.codebo
 #  - Ukrainian: "uk"
 #  - Norwegian: "nb_no", "nn_no"
 #  - Portuguese (Portugal): "pt_pt", "pt"
+#  - Persian/Farsi: "fa_ir"
 dictionaries = ["en_us", "en_gb"]
 
 # Custom allowlist of words to ignore (case-insensitive)

--- a/crates/codebook/src/dictionaries/repo.rs
+++ b/crates/codebook/src/dictionaries/repo.rs
@@ -174,6 +174,11 @@ static HUNSPELL_DICTIONARIES: LazyLock<Vec<HunspellRepo>> = LazyLock::new(|| {
             "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/pt/index.aff",
             "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/pt/index.dic",
         ),
+        HunspellRepo::new(
+            "fa_ir",
+            "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/fa/index.aff",
+            "https://raw.githubusercontent.com/blopker/dictionaries/refs/heads/main/dictionaries/fa/index.dic",
+        ),
     ]
 });
 


### PR DESCRIPTION
## Summary

Adds Persian/Farsi Hunspell dictionary support under the dictionary name `fa_ir`.

## Changes

- Adds `fa_ir` to `HUNSPELL_DICTIONARIES`
- Uses the Persian Hunspell `.aff` and `.dic` files from `wooorm/dictionaries`
- Documents `fa_ir` in the README available dictionaries list

## Testing

- [x] `cargo test test_dictionary_names_unique_and_snake_case`
- [x] `make test`

## Usage

```toml
dictionaries = ["en_us", "fa_ir"]