### PR TITLE
C/C++: Spell-check declarators without initializers (Closes #255)

### DIFF
--- a/crates/codebook/src/queries/c.scm
+++ b/crates/codebook/src/queries/c.scm
@@ -17,6 +17,8 @@
     declarator: (identifier) @identifier.variable)
 (pointer_declarator
     declarator: (identifier) @identifier.variable)
+(declaration
+    declarator: (identifier) @identifier.variable)
 (init_declarator
     (string_literal
         (string_content) @string))

--- a/crates/codebook/src/queries/cpp.scm
+++ b/crates/codebook/src/queries/cpp.scm
@@ -30,6 +30,9 @@
 (pointer_declarator
   declarator: (identifier) @identifier.variable)
 
+(declaration
+    declarator: (identifier) @identifier.variable)
+
 (init_declarator
   (string_literal
     (string_content) @string))

--- a/crates/codebook/tests/languages/test_c.rs
+++ b/crates/codebook/tests/languages/test_c.rs
@@ -11,13 +11,16 @@ fn test_c_simple() {
         int calculatr(int numbr1, int numbr2, char operashun) {
             // This is an exampl function that performz calculashuns
             int resalt = 0;
-            return resalt;
+            int misspellled;
+            misspellled = 20;
+            return resalt + misspellled;
         }
     "#;
     let expected = vec![
         "calculashuns",
         "calculatr",
         "exampl",
+        "misspellled",
         "numbr",
         "operashun",
         "performz",

--- a/crates/codebook/tests/languages/test_cpp.rs
+++ b/crates/codebook/tests/languages/test_cpp.rs
@@ -11,13 +11,16 @@ fn test_cpp_simple() {
         int calculatr(int numbr1, int numbr2, char operashun) {
             // This is an exampl function that performz calculashuns
             int resalt = 0;
-            return resalt;
+            int misspellled;
+            misspellled = 20;
+            return resalt + misspellled;
         }
     "#;
     let expected = vec![
         "calculashuns",
         "calculatr",
         "exampl",
+        "misspellled",
         "numbr",
         "operashun",
         "performz",


### PR DESCRIPTION
Closes #255.

Add spell-checking support in C/C++ for declarators without identifiers. For example:

```c
int helloo;
```

This is my first time working with tree-sitter queries, so let me know if there's a better way to approach this.