### PR TITLE
C: enable spelling for new language constructs (Closes #257)

### DIFF
--- a/crates/codebook/src/queries/c.scm
+++ b/crates/codebook/src/queries/c.scm
@@ -1,13 +1,20 @@
 (comment) @comment
 (preproc_def
     name: (identifier) @identifier.constant)
+(preproc_function_def
+    name: (identifier) @identifier.function)
+(preproc_params) @identifier.parameter
 (type_definition
     declarator: (type_identifier) @identifier.type)
 (struct_specifier
     name: (type_identifier) @identifier.type)
+(union_specifier
+    name: (type_identifier) @identifier.type)
 (field_declaration
     declarator: (field_identifier) @identifier.field)
 (pointer_declarator
+    declarator: (field_identifier) @identifier.field)
+(array_declarator
     declarator: (field_identifier) @identifier.field)
 (enum_specifier
     name: (type_identifier) @identifier.type)
@@ -19,14 +26,10 @@
     declarator: (identifier) @identifier.variable)
 (declaration
     declarator: (identifier) @identifier.variable)
-(init_declarator
-    (string_literal
-        (string_content) @string))
+(array_declarator
+    declarator: (identifier) @identifier.variable)
 (function_declarator
     declarator: (identifier) @identifier.function)
 (parameter_declaration
     declarator: (identifier) @identifier.parameter)
-    (call_expression
-        (argument_list
-            (string_literal
-                [(string_content) (escape_sequence)] @string)))
+(string_content) @string

--- a/crates/codebook/tests/languages/test_c.rs
+++ b/crates/codebook/tests/languages/test_c.rs
@@ -12,7 +12,6 @@ fn test_c_simple() {
             // This is an exampl function that performz calculashuns
             int resalt = 0;
             int misspellled;
-            misspellled = 20;
             return resalt + misspellled;
         }
     "#;
@@ -111,4 +110,368 @@ fn test_c_struct() {
         assert_eq!(result.word, expect.word);
         assert_eq!(result.locations, expect.locations);
     }
+}
+
+#[test]
+fn test_c_macros() {
+    super::utils::init_logging();
+    let sample_text = r#"
+        #define MACROCONST 3
+        #define MACROFUNC(macroparam) macroparam + 1
+    "#;
+    // Needs to be lexicographically sorted
+    let expected = [
+        WordLocation::new(
+            "MACROCONST".to_string(),
+            vec![TextRange {
+                start_byte: 17,
+                end_byte: 27,
+            }],
+        ),
+        WordLocation::new(
+            "MACROFUNC".to_string(),
+            vec![TextRange {
+                start_byte: 46,
+                end_byte: 55,
+            }],
+        ),
+        WordLocation::new(
+            "macroparam".to_string(),
+            vec![TextRange {
+                start_byte: 56,
+                end_byte: 66,
+            }],
+        ),
+    ];
+    let processor = super::utils::get_processor();
+    let mut misspelled = processor.spell_check(sample_text, Some(LanguageType::C), None);
+    misspelled.sort_by(|loc1, loc2| loc1.word.cmp(&loc2.word));
+    assert_eq!(misspelled, expected);
+}
+
+#[test]
+fn test_c_unions() {
+    super::utils::init_logging();
+    let sample_text = r#"union myunion { int int_val; };"#;
+
+    // Needs to be lexicographically sorted
+    let expected = [WordLocation::new(
+        "myunion".to_string(),
+        vec![TextRange {
+            start_byte: 6,
+            end_byte: 13,
+        }],
+    )];
+    let processor = super::utils::get_processor();
+    let mut misspelled = processor.spell_check(sample_text, Some(LanguageType::C), None);
+    misspelled.sort_by(|loc1, loc2| loc1.word.cmp(&loc2.word));
+    assert_eq!(misspelled, expected);
+}
+
+#[test]
+fn test_c_variable_declarations() {
+    super::utils::init_logging();
+    let sample_text = r#"
+        int arrayy[3];
+        int* pointerr;
+        int* pointerrarray[3];
+        enum Role rolee;
+        union Union unionn;
+        struct User userr;"#;
+
+    // Needs to be lexicographically sorted
+    let expected = [
+        WordLocation::new(
+            "arrayy".to_string(),
+            vec![TextRange {
+                start_byte: 13,
+                end_byte: 19,
+            }],
+        ),
+        WordLocation::new(
+            "pointerr".to_string(),
+            vec![TextRange {
+                start_byte: 37,
+                end_byte: 45,
+            }],
+        ),
+        WordLocation::new(
+            "pointerrarray".to_string(),
+            vec![TextRange {
+                start_byte: 60,
+                end_byte: 73,
+            }],
+        ),
+        WordLocation::new(
+            "rolee".to_string(),
+            vec![TextRange {
+                start_byte: 96,
+                end_byte: 101,
+            }],
+        ),
+        WordLocation::new(
+            "unionn".to_string(),
+            vec![TextRange {
+                start_byte: 123,
+                end_byte: 129,
+            }],
+        ),
+        WordLocation::new(
+            "userr".to_string(),
+            vec![TextRange {
+                start_byte: 151,
+                end_byte: 156,
+            }],
+        ),
+    ];
+    let processor = super::utils::get_processor();
+    let mut misspelled = processor.spell_check(sample_text, Some(LanguageType::C), None);
+    misspelled.sort_by(|loc1, loc2| loc1.word.cmp(&loc2.word));
+    assert_eq!(misspelled, expected);
+}
+
+#[test]
+fn test_c_variable_initializers() {
+    super::utils::init_logging();
+    // Note: variables with initializers have slightly different syntax tree
+    // representations, so it useful to test them along with plain declarations.
+    let sample_text = r#"
+        int arrayy[3] = {};
+        int* pointerr = NULL;
+        int* pointerrarray[3] = {};
+        enum Role rolee = ROLE1;
+        union Union unionn = 10;
+        struct User userr = {};"#;
+
+    // Needs to be lexicographically sorted
+    let expected = [
+        WordLocation::new(
+            "arrayy".to_string(),
+            vec![TextRange {
+                start_byte: 13,
+                end_byte: 19,
+            }],
+        ),
+        WordLocation::new(
+            "pointerr".to_string(),
+            vec![TextRange {
+                start_byte: 42,
+                end_byte: 50,
+            }],
+        ),
+        WordLocation::new(
+            "pointerrarray".to_string(),
+            vec![TextRange {
+                start_byte: 72,
+                end_byte: 85,
+            }],
+        ),
+        WordLocation::new(
+            "rolee".to_string(),
+            vec![TextRange {
+                start_byte: 113,
+                end_byte: 118,
+            }],
+        ),
+        WordLocation::new(
+            "unionn".to_string(),
+            vec![TextRange {
+                start_byte: 148,
+                end_byte: 154,
+            }],
+        ),
+        WordLocation::new(
+            "userr".to_string(),
+            vec![TextRange {
+                start_byte: 181,
+                end_byte: 186,
+            }],
+        ),
+    ];
+    let processor = super::utils::get_processor();
+    let mut misspelled = processor.spell_check(sample_text, Some(LanguageType::C), None);
+    misspelled.sort_by(|loc1, loc2| loc1.word.cmp(&loc2.word));
+    assert_eq!(misspelled, expected);
+}
+
+#[test]
+fn test_c_field_declarations() {
+    super::utils::init_logging();
+    let sample_text = r#"
+        struct MyStruct {
+            int arrayy[3];
+            int* pointerr;
+            int* pointerrarray[3];
+            enum Role rolee;
+            union Union unionn;
+            struct User userr;
+        }"#;
+
+    // Needs to be lexicographically sorted
+    let expected = [
+        WordLocation::new(
+            "arrayy".to_string(),
+            vec![TextRange {
+                start_byte: 43,
+                end_byte: 49,
+            }],
+        ),
+        WordLocation::new(
+            "pointerr".to_string(),
+            vec![TextRange {
+                start_byte: 71,
+                end_byte: 79,
+            }],
+        ),
+        WordLocation::new(
+            "pointerrarray".to_string(),
+            vec![TextRange {
+                start_byte: 98,
+                end_byte: 111,
+            }],
+        ),
+        WordLocation::new(
+            "rolee".to_string(),
+            vec![TextRange {
+                start_byte: 138,
+                end_byte: 143,
+            }],
+        ),
+        WordLocation::new(
+            "unionn".to_string(),
+            vec![TextRange {
+                start_byte: 169,
+                end_byte: 175,
+            }],
+        ),
+        WordLocation::new(
+            "userr".to_string(),
+            vec![TextRange {
+                start_byte: 201,
+                end_byte: 206,
+            }],
+        ),
+    ];
+    let processor = super::utils::get_processor();
+    let mut misspelled = processor.spell_check(sample_text, Some(LanguageType::C), None);
+    misspelled.sort_by(|loc1, loc2| loc1.word.cmp(&loc2.word));
+    assert_eq!(misspelled, expected);
+}
+
+#[test]
+fn test_c_strings() {
+    super::utils::init_logging();
+
+    // Note: we do not do spell checking across string concatenations,
+    // just individual strings.
+    let sample_text = r#"
+        char* str1 = "aaaa bbbb";
+        str1 = "cccc" "valid string" "dddd";
+        printf("I'm a multiline stringg\n"
+               "withh\nyyy");
+    "#;
+
+    // Needs to be lexicographically sorted
+    let expected = [
+        WordLocation::new(
+            "aaaa".to_string(),
+            vec![TextRange {
+                start_byte: 23,
+                end_byte: 27,
+            }],
+        ),
+        WordLocation::new(
+            "bbbb".to_string(),
+            vec![TextRange {
+                start_byte: 28,
+                end_byte: 32,
+            }],
+        ),
+        WordLocation::new(
+            "cccc".to_string(),
+            vec![TextRange {
+                start_byte: 51,
+                end_byte: 55,
+            }],
+        ),
+        WordLocation::new(
+            "dddd".to_string(),
+            vec![TextRange {
+                start_byte: 73,
+                end_byte: 77,
+            }],
+        ),
+        WordLocation::new(
+            "stringg".to_string(),
+            vec![TextRange {
+                start_byte: 112,
+                end_byte: 119,
+            }],
+        ),
+        WordLocation::new(
+            "withh".to_string(),
+            vec![TextRange {
+                start_byte: 139,
+                end_byte: 144,
+            }],
+        ),
+        WordLocation::new(
+            "yyy".to_string(),
+            vec![TextRange {
+                start_byte: 146,
+                end_byte: 149,
+            }],
+        ),
+    ];
+    let processor = super::utils::get_processor();
+    let mut misspelled = processor.spell_check(sample_text, Some(LanguageType::C), None);
+    misspelled.sort_by(|loc1, loc2| loc1.word.cmp(&loc2.word));
+    assert_eq!(misspelled, expected);
+}
+
+#[test]
+fn test_c_typedef() {
+    super::utils::init_logging();
+    let sample_text = r#"typedef int Mispelll;"#;
+
+    // Needs to be lexicographically sorted
+    let expected = [WordLocation::new(
+        "Mispelll".to_string(),
+        vec![TextRange {
+            start_byte: 12,
+            end_byte: 20,
+        }],
+    )];
+    let processor = super::utils::get_processor();
+    let mut misspelled = processor.spell_check(sample_text, Some(LanguageType::C), None);
+    misspelled.sort_by(|loc1, loc2| loc1.word.cmp(&loc2.word));
+    assert_eq!(misspelled, expected);
+}
+
+#[test]
+fn test_c_enum() {
+    super::utils::init_logging();
+    let sample_text = r#"enum Colrs { Grean };"#;
+
+    // Needs to be lexicographically sorted
+    let expected = [
+        WordLocation::new(
+            "Colrs".to_string(),
+            vec![TextRange {
+                start_byte: 5,
+                end_byte: 10,
+            }],
+        ),
+        WordLocation::new(
+            "Grean".to_string(),
+            vec![TextRange {
+                start_byte: 13,
+                end_byte: 18,
+            }],
+        ),
+    ];
+    let processor = super::utils::get_processor();
+    let mut misspelled = processor.spell_check(sample_text, Some(LanguageType::C), None);
+    misspelled.sort_by(|loc1, loc2| loc1.word.cmp(&loc2.word));
+    assert_eq!(misspelled, expected);
 }


### PR DESCRIPTION
Closes #257.

1. Make C unit tests exhaustive for all the queries in `c.scm` (though not necessarily a full reflection of every C language feature).
   2. Add spell checking for macro functions and parameters: `#define MACRO_FUNCTION(macro_param) macro_param + 1`.
3. Add spell checking for named unions: `union MyUnion {}`.
4. Add spell checking for array fields and variables: `int nums[20]`.
5. Made string checking more general. This change ensures that `string1` and `string2` are both spell-checked in the example `"string1\nstring2"`. Also string literals outside of function calls and initializers (e.g., during assignment) also get checked.