### PR TITLE
C: don't spell-check type usages

### DIFF
--- a/crates/codebook/src/queries/c.scm
+++ b/crates/codebook/src/queries/c.scm
@@ -7,9 +7,11 @@
 (type_definition
     declarator: (type_identifier) @identifier.type)
 (struct_specifier
-    name: (type_identifier) @identifier.type)
+    name: (type_identifier) @identifier.type
+    body: _)
 (union_specifier
-    name: (type_identifier) @identifier.type)
+    name: (type_identifier) @identifier.type
+    body: _)
 (field_declaration
     declarator: (field_identifier) @identifier.field)
 (pointer_declarator
@@ -17,7 +19,8 @@
 (array_declarator
     declarator: (field_identifier) @identifier.field)
 (enum_specifier
-    name: (type_identifier) @identifier.type)
+    name: (type_identifier) @identifier.type
+    body: _)
 (enumerator
     name: (identifier) @identifier.constant)
 (init_declarator

--- a/crates/codebook/tests/languages/test_c.rs
+++ b/crates/codebook/tests/languages/test_c.rs
@@ -475,3 +475,17 @@ fn test_c_enum() {
     misspelled.sort_by(|loc1, loc2| loc1.word.cmp(&loc2.word));
     assert_eq!(misspelled, expected);
 }
+
+#[test]
+fn test_c_type_uses() {
+    super::utils::init_logging();
+    let sample_text = r#"
+        enum Colorr color;
+        union Dataa data;
+        struct Userr user;
+    "#;
+
+    let processor = super::utils::get_processor();
+    let misspelled = processor.spell_check(sample_text, Some(LanguageType::C), None);
+    assert_eq!(misspelled, []);
+}


### PR DESCRIPTION
Don't spell-check uses of C enums, structs, and unions. For example, no spell-checking should occur for the type names in the following example:

```c
enum Colorr color;
union Dataa data;
struct Userr user;
```

This is split from #266, which also includes infrastructure for simplifying test generation.