### PR TITLE
Normalize config paths across platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Glob syntax matches `ignore_paths`: `*` (no separator), `**` (any directories), 
 Editors can pass `initializationOptions` when starting the Codebook LSP for LSP-specific options. Refer to your editor's documentation for how to apply these options. All values are optional, omit them for the default behavior:
 
 - `logLevel` (`"trace" | "debug" | "info" | "warn" | "error"`, default `"info"`): sets the verbosity of logs.
-- `globalConfigPath` (string): overrides the auto-detected global `codebook.toml` path, useful if you sync configs from another location. On macOS and Linux, the `~/` prefix for the current user's home directory is supported.
+- `globalConfigPath` (string): overrides the auto-detected global `codebook.toml` path, useful if you sync configs from another location. The `~/` prefix resolves to the current user's home directory on all platforms.
 - `configPath` (string): overrides the project `codebook.toml` location. Relative paths are resolved against the workspace root, absolute paths are used as-is. When set, auto-discovery is skipped; the file is created at this path the first time Codebook needs to write (e.g., adding a word).
 - `checkWhileTyping` (bool, default `true`): when `false`, spelling diagnostics are only published on save instead of each keystroke. This is useful for example if performance is a problem, or the real-time diagnostics are annoying (sorry!).
 - `diagnosticSeverity` (`"error" | "warning" | "information" | "hint"`, default `"information"`): sets the severity of spell check diagnostics.

--- a/crates/codebook-config/src/helpers.rs
+++ b/crates/codebook-config/src/helpers.rs
@@ -74,28 +74,36 @@ pub fn build_ignore_regexes(patterns: &[String]) -> Vec<Regex> {
 
 pub(crate) fn expand_tilde<P: AsRef<Path>>(path_user_input: P) -> Option<PathBuf> {
     let p = path_user_input.as_ref();
-    if !p.starts_with("~") {
-        return Some(p.to_path_buf());
-    }
-    if p == Path::new("~") {
+    let path = p.to_string_lossy();
+
+    if path == "~" {
         return dirs::home_dir();
     }
-    dirs::home_dir().map(|mut h| {
-        if h == Path::new("/") {
-            // Corner case: `h` root directory;
-            // don't prepend extra `/`, just drop the tilde.
-            p.strip_prefix("~").unwrap().to_path_buf()
-        } else {
-            h.push(p.strip_prefix("~/").unwrap());
-            h
-        }
-    })
+
+    let rest = path.strip_prefix("~/");
+    #[cfg(windows)]
+    let rest = rest.or_else(|| path.strip_prefix("~\\"));
+
+    if let Some(rest) = rest {
+        return dirs::home_dir().map(|mut home| {
+            if home == Path::new("/") {
+                PathBuf::from(rest)
+            } else {
+                home.push(rest);
+                home
+            }
+        });
+    }
+
+    Some(p.to_path_buf())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(windows))]
     use std::ffi::OsString;
+    #[cfg(not(windows))]
     use std::sync::{Mutex, MutexGuard};
 
     #[cfg(not(windows))]
@@ -168,6 +176,28 @@ mod tests {
 
         restore_xdg(previous);
         drop(guard);
+    }
+
+    #[test]
+    fn expand_tilde_resolves_home_directory() {
+        let home = dirs::home_dir().expect("home directory must be available for the test");
+
+        assert_eq!(expand_tilde("~"), Some(home));
+    }
+
+    #[test]
+    fn expand_tilde_resolves_unix_style_home_path() {
+        let mut expected = dirs::home_dir().expect("home directory must be available for the test");
+        expected.push("dotfiles/codebook.toml");
+
+        assert_eq!(expand_tilde("~/dotfiles/codebook.toml"), Some(expected));
+    }
+
+    #[test]
+    fn expand_tilde_leaves_other_paths_unchanged() {
+        let path = PathBuf::from("~user/codebook.toml");
+
+        assert_eq!(expand_tilde(&path), Some(path));
     }
 
     #[test]

--- a/crates/codebook-lsp/src/lsp.rs
+++ b/crates/codebook-lsp/src/lsp.rs
@@ -54,7 +54,9 @@ fn compute_relative_path(
 
     match file_path.canonicalize() {
         Ok(canon_file_path) => match canon_file_path.strip_prefix(&workspace_canonical) {
-            Ok(relative) => relative.to_string_lossy().to_string(),
+            Ok(relative) => relative
+                .to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR, "/"),
             Err(_) => file_path.to_string_lossy().to_string(),
         },
         Err(_) => file_path.to_string_lossy().to_string(),


### PR DESCRIPTION
Expand `~` and `~/...` in config path overrides on Windows while keeping `~\...` style paths Windows only. Normalize workspace relative paths to forward slashes so config matching is consistent across platforms.

This is useful when using shared dotfiles across platforms, for example using the same global config in both WSL and Windows. Also makes workspace relative paths consistent. Note that this _may_ have a side effect if someone were using Windows specific override globs, e.g.
```toml
[[overrides]]
paths = ["src\\crates\\*.rs"]
```
