### PR TITLE
Fix --ast arg parsing for paths containing "codebook"

### DIFF
--- a/crates/codebook/src/main.rs
+++ b/crates/codebook/src/main.rs
@@ -17,9 +17,20 @@ fn main() {
             .windows(2)
             .find(|w| w[0] == "--lang")
             .map(|w| w[1].as_str());
-        let file_arg = args.iter().find(|a| {
-            *a != "--ast" && *a != "--lang" && !a.starts_with("--") && !a.contains("codebook")
-        });
+        // Skip argv[0] and flag values: the file is the first positional arg.
+        let mut file_arg = None;
+        let mut iter = args.iter().skip(1);
+        while let Some(arg) = iter.next() {
+            if arg == "--lang" {
+                iter.next();
+                continue;
+            }
+            if arg.starts_with("--") {
+                continue;
+            }
+            file_arg = Some(arg);
+            break;
+        }
         match file_arg {
             Some(path) => dump_ast(path, lang_override),
             None => eprintln!("Usage: codebook --ast <file> [--lang <language>]"),


### PR DESCRIPTION
The file finder excluded any arg containing "codebook" as a proxy for skipping argv[0], which broke on real paths inside this repo. It also treated the --lang value as the file when flags came first. Walk args after argv[0] and skip flags and their values instead.