### PR TITLE
Normalize config paths across platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ flag_words = []
 # Glob patterns for paths to include when spell checking (allowlist).
 # Only files matching one of these patterns will be spell-checked.
 # Empty means include everything.
+# Patterns always use `/` as the separator, on all platforms.
 # Example: ["src/**/*.rs", "lib/**/*.rs"]
 include_paths = []
 
@@ -481,7 +482,7 @@ dictionaries = ["de"]
 | `extra_flag_words`      | Appends to the resolved `flag_words` list. |
 | `extra_ignore_patterns` | Appends to the resolved `ignore_patterns` list. |
 
-Glob syntax matches `ignore_paths`: `*` (no separator), `**` (any directories), `?` (any single char), and `{a,b}` alternation.
+Glob syntax matches `ignore_paths`: `*` (no separator), `**` (any directories), `?` (any single char), and `{a,b}` alternation. Patterns always use `/` as the path separator, like `.gitignore`. On Windows, file paths are normalized to forward slashes before matching, and backslash-style patterns (e.g. `src\\*.rs`) are not supported.
 
 **Resolution order:** all matching overrides are applied in declaration order, so later blocks win on the same field. Global overrides are applied before project overrides, so project settings always have the final say. If both a replace field (e.g., `words`) and its append sibling (`extra_words`) appear in the same block, replace runs first and then append is layered on top.
 
@@ -494,7 +495,7 @@ Glob syntax matches `ignore_paths`: `*` (no separator), `**` (any directories), 
 Editors can pass `initializationOptions` when starting the Codebook LSP for LSP-specific options. Refer to your editor's documentation for how to apply these options. All values are optional, omit them for the default behavior:
 
 - `logLevel` (`"trace" | "debug" | "info" | "warn" | "error"`, default `"info"`): sets the verbosity of logs.
-- `globalConfigPath` (string): overrides the auto-detected global `codebook.toml` path, useful if you sync configs from another location. On macOS and Linux, the `~/` prefix for the current user's home directory is supported.
+- `globalConfigPath` (string): overrides the auto-detected global `codebook.toml` path, useful if you sync configs from another location. The `~/` prefix resolves to the current user's home directory on all platforms (`~\` also works on Windows), so the same setting can be shared across Windows, macOS, and Linux dotfiles.
 - `configPath` (string): overrides the project `codebook.toml` location. Relative paths are resolved against the workspace root, absolute paths are used as-is. When set, auto-discovery is skipped; the file is created at this path the first time Codebook needs to write (e.g., adding a word).
 - `checkWhileTyping` (bool, default `true`): when `false`, spelling diagnostics are only published on save instead of each keystroke. This is useful for example if performance is a problem, or the real-time diagnostics are annoying (sorry!).
 - `diagnosticSeverity` (`"error" | "warning" | "information" | "hint"`, default `"information"`): sets the severity of spell check diagnostics.

--- a/crates/codebook-config/src/helpers.rs
+++ b/crates/codebook-config/src/helpers.rs
@@ -72,30 +72,37 @@ pub fn build_ignore_regexes(patterns: &[String]) -> Vec<Regex> {
         .collect()
 }
 
+/// Expand `~` and `~/` prefixes to the current user's home directory on all
+/// platforms (`~\` is also accepted on Windows, where it is a separator).
+/// Other paths, including `~user/...`, are returned unchanged.
 pub(crate) fn expand_tilde<P: AsRef<Path>>(path_user_input: P) -> Option<PathBuf> {
     let p = path_user_input.as_ref();
-    if !p.starts_with("~") {
-        return Some(p.to_path_buf());
-    }
-    if p == Path::new("~") {
+    let path = p.to_string_lossy();
+
+    if path == "~" {
         return dirs::home_dir();
     }
-    dirs::home_dir().map(|mut h| {
-        if h == Path::new("/") {
-            // Corner case: `h` root directory;
-            // don't prepend extra `/`, just drop the tilde.
-            p.strip_prefix("~").unwrap().to_path_buf()
-        } else {
-            h.push(p.strip_prefix("~/").unwrap());
-            h
+
+    let rest = path.strip_prefix("~/");
+    #[cfg(windows)]
+    let rest = rest.or_else(|| path.strip_prefix("~\\"));
+
+    match rest {
+        // Trim any extra leading separators (e.g. `~//x`): join with an
+        // absolute remainder would replace the home directory entirely.
+        Some(rest) => {
+            dirs::home_dir().map(|home| home.join(rest.trim_start_matches(std::path::is_separator)))
         }
-    })
+        None => Some(p.to_path_buf()),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(windows))]
     use std::ffi::OsString;
+    #[cfg(not(windows))]
     use std::sync::{Mutex, MutexGuard};
 
     #[cfg(not(windows))]
@@ -168,6 +175,57 @@ mod tests {
 
         restore_xdg(previous);
         drop(guard);
+    }
+
+    #[test]
+    fn expand_tilde_resolves_home_directory() {
+        let home = dirs::home_dir().expect("home directory must be available for the test");
+
+        assert_eq!(expand_tilde("~"), Some(home));
+    }
+
+    #[test]
+    fn expand_tilde_resolves_unix_style_home_path() {
+        let home = dirs::home_dir().expect("home directory must be available for the test");
+
+        assert_eq!(
+            expand_tilde("~/dotfiles/codebook.toml"),
+            Some(home.join("dotfiles/codebook.toml"))
+        );
+    }
+
+    #[test]
+    fn expand_tilde_stays_within_home_on_extra_separators() {
+        let home = dirs::home_dir().expect("home directory must be available for the test");
+
+        assert_eq!(expand_tilde("~//etc/passwd"), Some(home.join("etc/passwd")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn expand_tilde_resolves_windows_style_home_path() {
+        let home = dirs::home_dir().expect("home directory must be available for the test");
+
+        assert_eq!(
+            expand_tilde(r"~\dotfiles\codebook.toml"),
+            Some(home.join(r"dotfiles\codebook.toml"))
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn expand_tilde_leaves_windows_style_path_unchanged_on_unix() {
+        // On Unix `\` is an ordinary filename character, not a separator.
+        let path = PathBuf::from(r"~\dotfiles\codebook.toml");
+
+        assert_eq!(expand_tilde(&path), Some(path));
+    }
+
+    #[test]
+    fn expand_tilde_leaves_other_paths_unchanged() {
+        let path = PathBuf::from("~user/codebook.toml");
+
+        assert_eq!(expand_tilde(&path), Some(path));
     }
 
     #[test]

--- a/crates/codebook-config/src/settings.rs
+++ b/crates/codebook-config/src/settings.rs
@@ -115,7 +115,7 @@ impl OverrideBlock {
 
     /// Check if this override applies to the given relative file path.
     pub fn matches_path(&self, relative_path: &Path) -> bool {
-        let path_str = relative_path.to_string_lossy();
+        let path_str = normalize_separators(&relative_path.to_string_lossy());
         self.paths.iter().any(|pattern| {
             Pattern::new(pattern)
                 .map(|p| p.matches(&path_str))
@@ -362,7 +362,7 @@ impl ConfigSettings {
 
     /// Insert a path into the ignore list, returning true when it was newly added.
     pub fn insert_ignore(&mut self, file: &str) -> bool {
-        let file = file.to_string();
+        let file = normalize_separators(file);
         if self.ignore_paths.contains(&file) {
             return false;
         }
@@ -374,7 +374,7 @@ impl ConfigSettings {
 
     /// Insert a path into the include list, returning true when it was newly added.
     pub fn insert_include(&mut self, file: &str) -> bool {
-        let file = file.to_string();
+        let file = normalize_separators(file);
         if self.include_paths.contains(&file) {
             return false;
         }
@@ -398,13 +398,13 @@ impl ConfigSettings {
         if self.include_paths.is_empty() {
             return true;
         }
-        let path_str = path.to_string_lossy();
+        let path_str = normalize_separators(&path.to_string_lossy());
         match_pattern(&self.include_paths, &path_str)
     }
 
     /// Determine whether a path should be ignored based on the configured glob patterns.
     pub fn should_ignore_path(&self, path: &Path) -> bool {
-        let path_str = path.to_string_lossy();
+        let path_str = normalize_separators(&path.to_string_lossy());
         match_pattern(&self.ignore_paths, &path_str)
     }
 
@@ -432,6 +432,21 @@ fn match_pattern(patterns: &[String], path_str: &str) -> bool {
             .map(|p| p.matches(path_str))
             .unwrap_or(false)
     })
+}
+
+/// Config globs always use `/` as the separator, like `.gitignore`, so on
+/// Windows native `\` separators are normalized to `/`, both for paths being
+/// matched and for paths stored as glob entries. Stored entries especially
+/// must use `/` to stay portable: in a pattern `\` is a literal character on
+/// Unix, so an entry written with backslashes on Windows would silently stop
+/// matching when the config is shared to WSL/macOS/Linux.
+/// On Unix `\` is an ordinary filename character and paths are left alone.
+fn normalize_separators(path_str: &str) -> String {
+    if cfg!(windows) {
+        path_str.replace('\\', "/")
+    } else {
+        path_str.to_string()
+    }
 }
 
 /// Helper function to sort and deduplicate a Vec of strings
@@ -913,6 +928,53 @@ mod tests {
         assert!(ovr.matches_path(Path::new("src/guide.md")));
         assert!(ovr.matches_path(Path::new("docs/api/index.html")));
         assert!(!ovr.matches_path(Path::new("src/main.rs")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_override_matches_backslash_path_on_windows() {
+        let ovr = OverrideBlock {
+            paths: vec!["docs/**/*".to_string()],
+            extra_words: Some(vec!["test".to_string()]),
+            ..OverrideBlock::default_for_test()
+        };
+
+        assert!(ovr.matches_path(Path::new(r"docs\api\guide.md")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_ignore_and_include_match_backslash_paths_on_windows() {
+        let settings = ConfigSettings {
+            include_paths: vec!["src/**/*.rs".to_string()],
+            ignore_paths: vec!["target/**/*".to_string()],
+            ..Default::default()
+        };
+
+        assert!(settings.should_include_path(Path::new(r"src\main.rs")));
+        assert!(settings.should_ignore_path(Path::new(r"target\debug\build")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_insert_ignore_normalizes_separators_on_windows() {
+        let mut settings = ConfigSettings::default();
+
+        // Stored entries become glob patterns and must use `/` so they stay
+        // portable when the config is shared with Unix platforms.
+        assert!(settings.insert_ignore(r"src\notes.md"));
+        assert_eq!(settings.ignore_paths, vec!["src/notes.md"]);
+        assert!(settings.should_ignore_path(Path::new(r"src\notes.md")));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_backslash_is_not_a_separator_on_unix() {
+        let mut settings = ConfigSettings::default();
+
+        // On Unix `\` is an ordinary filename character and is preserved.
+        assert!(settings.insert_ignore(r"weird\name.md"));
+        assert_eq!(settings.ignore_paths, vec![r"weird\name.md"]);
     }
 
     #[test]


### PR DESCRIPTION
Expand `~` and `~/` config path overrides to the home directory on all platforms (`~\` stays Windows-only). Extra leading separators are trimmed so a path like ~//x resolves inside home instead of escaping to /x, and the home == "/" special case is dropped since join handles a root home correctly.

Glob matching follows the .gitignore model: patterns always use / as the separator. On Windows, native \ separators are normalized to / inside the codebook-config matcher, covering every producer (LSP, CLI, fallback paths). Entries stored by ignoreFile/include actions are normalized the same way so configs written on Windows keep matching when shared with WSL, macOS, or Linux.