### PR TITLE
Add use_local setting

### DIFF
--- a/crates/codebook-config/src/lib.rs
+++ b/crates/codebook-config/src/lib.rs
@@ -53,6 +53,7 @@ pub trait CodebookConfig: Sync + Send + Debug {
     fn should_flag_word(&self, word: &str) -> bool;
     fn get_ignore_patterns(&self) -> Vec<Regex>;
     fn get_min_word_length(&self) -> usize;
+    fn use_local(&self) -> bool;
     fn should_check_tag(&self, tag: &str) -> bool;
     fn cache_dir(&self) -> &Path;
 
@@ -284,6 +285,17 @@ impl CodebookConfigFile {
             .content()
             .cloned()
             .unwrap_or_else(ConfigSettings::default);
+
+        if !project.use_local {
+            return if project.use_global {
+                global_config
+                    .content()
+                    .cloned()
+                    .unwrap_or_else(ConfigSettings::default)
+            } else {
+                ConfigSettings::default()
+            };
+        }
 
         if project.use_global {
             if let Some(global) = global_config.content() {
@@ -543,6 +555,10 @@ impl CodebookConfig for CodebookConfigFile {
         self.snapshot().min_word_length()
     }
 
+    fn use_local(&self) -> bool {
+        self.snapshot().use_local
+    }
+
     fn should_check_tag(&self, tag: &str) -> bool {
         self.snapshot().should_check_tag(tag)
     }
@@ -650,6 +666,10 @@ impl CodebookConfig for CodebookConfigMemory {
 
     fn get_min_word_length(&self) -> usize {
         self.snapshot().min_word_length()
+    }
+
+    fn use_local(&self) -> bool {
+        self.snapshot().use_local
     }
 
     fn should_check_tag(&self, tag: &str) -> bool {

--- a/crates/codebook-config/src/settings.rs
+++ b/crates/codebook-config/src/settings.rs
@@ -267,6 +267,13 @@ pub struct ConfigSettings {
     )]
     pub ignore_patterns: Vec<Regex>,
 
+    /// Whether to use local (project) configuration
+    #[serde(
+        default = "default_use_local",
+        skip_serializing_if = "is_default_use_local"
+    )]
+    pub use_local: bool,
+
     /// Whether to use global configuration
     #[serde(
         default = "default_use_global",
@@ -305,6 +312,14 @@ fn is_default_use_global(value: &bool) -> bool {
     *value == default_use_global()
 }
 
+fn default_use_local() -> bool {
+    true
+}
+
+fn is_default_use_local(value: &bool) -> bool {
+    *value == default_use_local()
+}
+
 fn default_min_word_length() -> usize {
     3
 }
@@ -319,6 +334,7 @@ impl Default for ConfigSettings {
             ignore_paths: Vec::new(),
             ignore_patterns: Vec::new(),
             use_global: true,
+            use_local: true,
             min_word_length: None,
             include_tags: Vec::new(),
             exclude_tags: Vec::new(),

--- a/crates/codebook-lsp/src/lsp.rs
+++ b/crates/codebook-lsp/src/lsp.rs
@@ -230,6 +230,7 @@ impl LanguageServer for Backend {
             None => return Ok(None),
         };
 
+        let use_local = self.config_handle().use_local();
         let mut has_codebook_diagnostic = false;
         for diag in params.context.diagnostics {
             // Only process our own diagnostics
@@ -277,20 +278,22 @@ impl LanguageServer for Backend {
                     &params.text_document.uri,
                 )));
             });
-            actions.push(CodeActionOrCommand::CodeAction(CodeAction {
-                title: format!("Add '{word}' to dictionary"),
-                kind: Some(CodeActionKind::QUICKFIX),
-                diagnostics: None,
-                edit: None,
-                command: Some(Command {
+            if use_local {
+                actions.push(CodeActionOrCommand::CodeAction(CodeAction {
                     title: format!("Add '{word}' to dictionary"),
-                    command: CodebookCommand::AddWord.into(),
-                    arguments: Some(vec![word.to_string().into()]),
-                }),
-                is_preferred: None,
-                disabled: None,
-                data: None,
-            }));
+                    kind: Some(CodeActionKind::QUICKFIX),
+                    diagnostics: None,
+                    edit: None,
+                    command: Some(Command {
+                        title: format!("Add '{word}' to dictionary"),
+                        command: CodebookCommand::AddWord.into(),
+                        arguments: Some(vec![word.to_string().into()]),
+                    }),
+                    is_preferred: None,
+                    disabled: None,
+                    data: None,
+                }));
+            }
             actions.push(CodeActionOrCommand::CodeAction(CodeAction {
                 title: format!("Add '{word}' to global dictionary"),
                 kind: Some(CodeActionKind::QUICKFIX),
@@ -306,7 +309,7 @@ impl LanguageServer for Backend {
                 data: None,
             }));
         }
-        if has_codebook_diagnostic {
+        if has_codebook_diagnostic && use_local {
             actions.push(CodeActionOrCommand::CodeAction(CodeAction {
                 title: "Add current file to ignore list".to_string(),
                 kind: Some(CodeActionKind::QUICKFIX),


### PR DESCRIPTION
I did not like [1] the presence of suggestions to create project-local dictionaries or exclusion lists, so I thought this could be a useful feature (analogous to `use_global`) to allow disabling them.

[1] I think [this](https://ziggit.dev/t/whats-the-state-of-the-art-in-zig-ecosystem-for-wayland-vulkan-without-libc-2/16415/53) post by Andrew Kelley explains the reasoning best.