### PR TITLE
Spell check Markdown table cells

### DIFF
--- a/crates/codebook/src/queries/markdown.scm
+++ b/crates/codebook/src/queries/markdown.scm
@@ -4,3 +4,4 @@
 (fenced_code_block
   (info_string (language) @injection.language)
   (code_fence_content) @injection.content)
+(pipe_table_cell) @string

--- a/crates/codebook/tests/languages/test_markdown.rs
+++ b/crates/codebook/tests/languages/test_markdown.rs
@@ -174,3 +174,22 @@ fn test_markdown_no_duplicate_spans() {
         &[("tyypo", &[0]), ("quoet", &[0])],
     );
 }
+
+#[test]
+fn test_markdown_tables() {
+    let sample_text = r#"Some correct text here.
+
+| hyeder | **bould** |
+| :----: | --------- |
+| taipo  | `coode`   |
+
+More correct text here.
+"#;
+
+    assert_spelling(
+        LanguageType::Markdown,
+        sample_text,
+        &["hyeder", "bould", "taipo", "coode"],
+        &[],
+    );
+}


### PR DESCRIPTION
Currently, Markdown tables don't seem to be checked at all. This PR adds `pipe_table_cell` to the Markdown query file and a test confirming that misspelled words in both header rows and regular rows are checked regardless of various other Markdown syntax supported in tables.